### PR TITLE
Updating the location of the hash for methods on the API site

### DIFF
--- a/sensio/sphinx/phpcode.py
+++ b/sensio/sphinx/phpcode.py
@@ -66,7 +66,7 @@ def php_method_role(typ, rawtext, text, lineno, inliner, options={}, content=[])
     method = class_and_method[ns+2:]
 
     try:
-        full_url = base_url % full_class.replace('\\', '/') + '.html' + '#' + method + '()'
+        full_url = base_url % full_class.replace('\\', '/') + '.html' + '#method_' + method
     except (TypeError, ValueError):
         env.warn(env.docname, 'unable to expand %s api_url with base '
                  'URL %r, please make sure the base contains \'%%s\' '


### PR DESCRIPTION
See symfony/symfony-docs#1391

It seems that the hash anchor the the methods themselves changed recently and the generator for it should be updated. But, that change is just an assumption on my part, but this seems to update things to work :)

Thanks!
