### PR TITLE
Adding php-standalone and php-symfony

### DIFF
--- a/sensio/sphinx/configurationblock.py
+++ b/sensio/sphinx/configurationblock.py
@@ -29,6 +29,8 @@ class ConfigurationBlock(Directive):
         'html+php':        'PHP',
         'ini':             'INI',
         'php-annotations': 'Annotations',
+        'php-standalone':  'Standalone Use',
+        'php-symfony':     'Framework Use',
     }
 
     def run(self):


### PR DESCRIPTION
Hi Fabien!

Easy-enough addition, but thought I'd help anyways. This is for the form component documentation (symfony/symfony-docs#1883). It's still an experiment, but I think worth trying.

Two issues that you mentioned still are:

a) If we like this, we'll need to code so that a user can download different versions of the book
b) We don't have a solution yet for the printed book

I suppose that if this _is_ the right way to doc some of the components, then we'll figure out (b) when we need to. Also, for now, we're keeping the form book chapter in tact. So, the "form component" documentation for now is only really _needed_ for form component users (i.e. it would still be ok to print just the component-use version in a book).

Along with this, the `conf.py` file will need the following 2 lines added:

```
lexers['php-standalone'] = PhpLexer(startinline=True)
lexers['php-symfony'] = PhpLexer(startinline=True)
```

Thanks!
