### PR TITLE
support Python 3

### DIFF
--- a/sensio/sphinx/configurationblock.py
+++ b/sensio/sphinx/configurationblock.py
@@ -6,7 +6,6 @@
 
 from docutils.parsers.rst import Directive, directives
 from docutils import nodes
-from string import upper
 
 class configurationblock(nodes.General, nodes.Element):
     pass

--- a/sensio/sphinx/phpcode.py
+++ b/sensio/sphinx/phpcode.py
@@ -7,7 +7,6 @@
 from docutils import nodes, utils
 
 from sphinx.util.nodes import split_explicit_title
-from string import lower
 
 def php_namespace_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     text = utils.unescape(text)
@@ -82,7 +81,7 @@ def php_phpclass_role(typ, rawtext, text, lineno, inliner, options={}, content=[
     text = utils.unescape(text)
     has_explicit_title, title, full_class = split_explicit_title(text)
 
-    full_url = 'http://php.net/manual/en/class.%s.php' % lower(full_class)
+    full_url = 'http://php.net/manual/en/class.%s.php' % full_class.lower()
 
     if not has_explicit_title:
         title = full_class
@@ -98,7 +97,7 @@ def php_phpmethod_role(typ, rawtext, text, lineno, inliner, options={}, content=
     full_class = class_and_method[:ns]
     method = class_and_method[ns+2:]
 
-    full_url = 'http://php.net/manual/en/%s.%s.php' % (lower(full_class), lower(method))
+    full_url = 'http://php.net/manual/en/%s.%s.php' % (full_class.lower(), method.lower())
 
     if not has_explicit_title:
         title = full_class + '::' + method + '()'
@@ -110,7 +109,7 @@ def php_phpfunction_role(typ, rawtext, text, lineno, inliner, options={}, conten
     text = utils.unescape(text)
     has_explicit_title, title, full_function = split_explicit_title(text)
 
-    full_url = 'http://php.net/manual/en/function.%s.php' % lower(full_function.replace('_', '-'))
+    full_url = 'http://php.net/manual/en/function.%s.php' % full_function.replace('_', '-').lower()
 
     if not has_explicit_title:
         title = full_function


### PR DESCRIPTION
These changes enable the extension to be used with Python 3 while keeping it backwards compatible with Python 2.7 (see also #5).
