### PR TITLE
generate a warning message when backslashes in namespaces are not escaped properly

### DIFF
--- a/sensio/sphinx/phpcode.py
+++ b/sensio/sphinx/phpcode.py
@@ -4,6 +4,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import re
+
 from docutils import nodes, utils
 
 from sphinx.util.nodes import split_explicit_title
@@ -37,6 +39,9 @@ def php_class_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     base_url = env.app.config.api_url
     has_explicit_title, title, full_class = split_explicit_title(text)
 
+    if len(re.findall(r'[^\\]\\[^\\]', rawtext)) > 0:
+        env.warn(env.docname, 'backslash not escaped in %s' % rawtext, lineno)
+
     try:
         full_url = base_url % full_class.replace('\\', '/') + '.html'
     except (TypeError, ValueError):
@@ -63,6 +68,9 @@ def php_method_role(typ, rawtext, text, lineno, inliner, options={}, content=[])
     ns = class_and_method.rfind('::')
     full_class = class_and_method[:ns]
     method = class_and_method[ns+2:]
+
+    if len(re.findall(r'[^\\]\\[^\\]', rawtext)) > 0:
+        env.warn(env.docname, 'backslash not escaped in %s' % rawtext, lineno)
 
     try:
         full_url = base_url % full_class.replace('\\', '/') + '.html' + '#method_' + method


### PR DESCRIPTION
Running a build now procudes an output like this if backslashes are not escaped (see #11):

``` text
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.1.3
loading pickled environment... done
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] components/event_dispatcher/container_aware_dispatcher                                                                                        
/var/www/Symfony/docs/components/event_dispatcher/container_aware_dispatcher.rst:10: WARNING: backslash not escaped in :class:`Symfony\\Component\EventDispatcher\\ContainerAwareEventDispatcher`
/var/www/Symfony/docs/components/event_dispatcher/container_aware_dispatcher.rst:47: WARNING: backslash not escaped in :method:`Symfony\\Component\\EventDispatcher\ContainerAwareEventDispatcher::addListenerService`
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index                                                                                                                                          
writing additional files... genindex search
copying static files... done
dumping search index... done
dumping object inventory... done
build succeeded, 2 warnings.

Build finished. The HTML pages are in _build/html.
```
