### PR TITLE
use default highlight language if none was given

### DIFF
--- a/sensio/sphinx/configurationblock.py
+++ b/sensio/sphinx/configurationblock.py
@@ -54,8 +54,12 @@ class ConfigurationBlock(Directive):
                 #targetid = "configuration-block-%d" % env.new_serialno('configuration-block')
                 #targetnode = nodes.target('', '', ids=[targetid])
                 #targetnode.append(child)
+                if 'language' in child:
+                    language = child['language']
+                else:
+                    language = env.app.config.highlight_language
 
-                innernode = nodes.emphasis(self.formats[child['language']], self.formats[child['language']])
+                innernode = nodes.emphasis(self.formats[language], self.formats[language])
 
                 para = nodes.paragraph()
                 para += [innernode, child]


### PR DESCRIPTION
When using the `literalinclude` directive inside a configuration
block, it's a tedious task to always pass the language used to
highlight the included code file like this:

```
.. configuration-block::

    .. literalinclude:: /foo.php
        :language: php
```

Now, you can omit the `language` to let the file being rendered with
the language configured by the `highlight_language` option:

```
.. configuration-block::

    .. literalinclude:: /foo.php
```

This way, a `literalinclude` directive used inside a configuration
block works in the same manner as outside of it.
