### PR TITLE
Fix markup of the bestpractice admonition

### DIFF
--- a/sensio/sphinx/bestpractice.py
+++ b/sensio/sphinx/bestpractice.py
@@ -31,7 +31,7 @@ class BestPractice(Directive):
         return ret
 
 def visit_bestpractice_node(self, node):
-    self.body.append(self.starttag(node, 'div', CLASS=('admonition best-practice')))
+    self.visit_admonition(node, 'best-practice')
     self.set_first_last(node)
 
 def depart_bestpractice_node(self, node):


### PR DESCRIPTION
The previous way tried to replicate the behaviour of `SensioHTMLTranslator.visit_admonition`. However, it wasn't complete, resulting in a very weird style for the (upcoming) platform.sh builds.

I see no reason to not use `SensioHTMLTranslator.visit_admonition`, after changing it to this, I got the styles correct.

/cc @javiereguiluz Can you maybe verify this change?
