### PR TITLE
Removed importing of unused symbol

### DIFF
--- a/sensio/sphinx/bestpractice.py
+++ b/sensio/sphinx/bestpractice.py
@@ -1,6 +1,5 @@
 from docutils.parsers.rst import Directive, directives
 from docutils import nodes
-from string import upper
 from sphinx.util.compat import make_admonition
 from sphinx import addnodes
 from sphinx.locale import _


### PR DESCRIPTION
I'm getting the following error with Python 3.5:
`Could not import extension sensio.sphinx.bestpractice (exception: cannot import name 'upper')`

It seems this package/symbol was removed in Python 3.5 or something, but this symbol is actually not used at all in this file.