### PR TITLE
Fix double closed div tags on best practices nodes

### DIFF
--- a/sensio/sphinx/bestpractice.py
+++ b/sensio/sphinx/bestpractice.py
@@ -34,7 +34,7 @@ def visit_bestpractice_node(self, node):
     self.set_first_last(node)
 
 def depart_bestpractice_node(self, node):
-    self.depart_admonition(node)
+    self.body.append('</div>\n')
 
 def setup(app):
     app.add_node(bestpractice, html=(visit_bestpractice_node, depart_bestpractice_node))


### PR DESCRIPTION
The `depart_adminition` function defined in https://github.com/symfony/symfony-docs/blob/master/_build/_theme/_exts/symfonycom/sphinx/__init__.py#L45 generates a double closing div tag (`</div></div>`), whereas the `visit_bestpractice_node` generates only one `<div>` tag.

The documentation files generated with the `make html` command on the [Symfony docs project](http://github.com/symfony/symfony-docs) are therefore not valid.

This PR fixes it.

_WARNING_ : I don't see the issue of the extra closing tags on the Symfony documentation website (e.g. There are 137 `<div>` and 137 `</div>` on http://symfony.com/doc/2.7/best_practices/business-logic.html), meaning that the `__init__.py` file may differ for the official documentation generation, making this PR useless. In that case, the `__init__.py` may need to be changed instead in the Symfony docs repository.