### PR TITLE
Declare extensions as parallel readsafe

### DIFF
--- a/sensio/sphinx/bestpractice.py
+++ b/sensio/sphinx/bestpractice.py
@@ -39,3 +39,5 @@ def depart_bestpractice_node(self, node):
 def setup(app):
     app.add_node(bestpractice, html=(visit_bestpractice_node, depart_bestpractice_node))
     app.add_directive('best-practice', BestPractice)
+
+    return {'parallel_read_safe': True}

--- a/sensio/sphinx/codeblock.py
+++ b/sensio/sphinx/codeblock.py
@@ -17,3 +17,5 @@ class NumberedCodeBlock(CodeBlock):
 def setup(app):
     app.add_directive('code-block', NumberedCodeBlock)
     app.add_directive('sourcecode', NumberedCodeBlock)
+
+    return {'parallel_read_safe': True}

--- a/sensio/sphinx/configurationblock.py
+++ b/sensio/sphinx/configurationblock.py
@@ -94,3 +94,5 @@ def setup(app):
                  latex=(visit_configurationblock_latex, depart_configurationblock_latex))
     app.add_directive('configuration-block', ConfigurationBlock)
     app.add_config_value('config_block', {}, 'env')
+
+    return {'parallel_read_safe': True}

--- a/sensio/sphinx/php.py
+++ b/sensio/sphinx/php.py
@@ -16,6 +16,8 @@ from sphinx.util.docfields import Field, GroupedField, TypedField
 def setup(app):
     app.add_domain(PHPDomain)
 
+    return {'parallel_read_safe': True}
+
 class PHPXRefRole(XRefRole):
     def process_link(self, env, refnode, has_explicit_title, title, target):
         # basically what sphinx.domains.python.PyXRefRole does

--- a/sensio/sphinx/phpcode.py
+++ b/sensio/sphinx/phpcode.py
@@ -127,6 +127,8 @@ def setup(app):
     app.add_role('phpmethod', php_phpmethod_role)
     app.add_role('phpfunction', php_phpfunction_role)
 
+    return {'parallel_read_safe': True}
+
 def build_url(role, namespace, class_name, method, inliner):
     env = inliner.document.settings.env
 


### PR DESCRIPTION
I'm trying to speed up the GitHub build actions on the symfony-docs by running Sphinx parallel. However, it requires extensions to explicitly mark themselves as parallel read safe (write safe is enabled automatically). It doesn't hurt to have this in here, so I suggest marking them as parallel readsafe.

I wasn't sure about the refinclude extension, but it seems like we do not use that extension in the Symfony docs. So I've left that one as not-parallel readsafe.