### PR TITLE
Fixed php.py to not import unused and inexistent "l_" symbol

### DIFF
--- a/sensio/sphinx/php.py
+++ b/sensio/sphinx/php.py
@@ -6,7 +6,7 @@
 
 from sphinx import addnodes
 from sphinx.domains import Domain, ObjType
-from sphinx.locale import l_, _
+from sphinx.locale import _
 from sphinx.directives import ObjectDescription
 from sphinx.domains.python import py_paramlist_re as js_paramlist_re
 from sphinx.roles import XRefRole


### PR DESCRIPTION
The ``"l_"`` symbol disappeared from ``sphinx.locale`` in sphinx 3.0 and this import caused the sphinx-php to fail with sphinx >= 3.0. Anyway, the symbol is not used anywhere in ``php.py``.