### PR TITLE
Fix enabling linenumbers by default

### DIFF
--- a/sensio/sphinx/codeblock.py
+++ b/sensio/sphinx/codeblock.py
@@ -30,7 +30,7 @@ class NumberedCodeBlock(CodeBlock):
     }
 
     def run(self):
-        self.options['linenos'] = 'table'
+        self.options['linenos'] = True
         literal = super(NumberedCodeBlock, self).run()[0];
 
         if 'zerocopy' in self.options:


### PR DESCRIPTION
`linenos` has become a `flag`, meaning it cannot have a value. This produces line numbers when testing locally