### PR TITLE
Support for "php-attributes" code blocks

### DIFF
--- a/sensio/sphinx/configurationblock.py
+++ b/sensio/sphinx/configurationblock.py
@@ -34,6 +34,7 @@ class ConfigurationBlock(Directive):
         'ini': 'INI',
         'markdown': 'Markdown',
         'php-annotations': 'Annotations',
+        'php-attributes': 'Attributes',
         'php-standalone': 'Standalone Use',
         'php-symfony': 'Framework Use',
         'rst': 'reStructuredText',


### PR DESCRIPTION
For my work on symfony/symfony-docs#14188, I need a way to express configuration samples with PHP attributes.

For instance, I'd like to add a tab "Attributes" to the code blocks on this page: https://symfony.com/doc/current/routing.html#matching-http-methods. The change proposed with this PR enables me to do that.